### PR TITLE
Store the CompressOptions struct on the stack

### DIFF
--- a/src/lz4/reader.cr
+++ b/src/lz4/reader.cr
@@ -22,7 +22,6 @@ class Compress::LZ4::Reader < ::IO
   getter compressed_bytes = 0u64
   getter uncompressed_bytes = 0u64
   @context : LibLZ4::Dctx
-  @opts = LibLZ4::DecompressOptionsT.new(stable_dst: 0)
 
   def initialize(@io : ::IO, @sync_close = false)
     ret = LibLZ4.create_decompression_context(out @context, LibLZ4::VERSION)
@@ -65,6 +64,7 @@ class Compress::LZ4::Reader < ::IO
   def read(slice : Bytes) : Int32
     check_open
     return 0 if slice.empty?
+    opts = LibLZ4::DecompressOptionsT.new(stable_dst: 0)
     decompressed_bytes = 0
     hint = 0u64 # the hint from the last decompression
     loop do
@@ -72,7 +72,7 @@ class Compress::LZ4::Reader < ::IO
       src_remaining = Math.min(hint, src_remaining) unless hint.zero?
       dst_remaining = slice.size.to_u64
 
-      hint = LibLZ4.decompress(@context, slice, pointerof(dst_remaining), @buffer_rem, pointerof(src_remaining), pointerof(@opts))
+      hint = LibLZ4.decompress(@context, slice, pointerof(dst_remaining), @buffer_rem, pointerof(src_remaining), pointerof(opts))
       raise_if_error(hint, "Failed to decompress")
 
       @buffer_rem += src_remaining

--- a/src/lz4/writer.cr
+++ b/src/lz4/writer.cr
@@ -30,7 +30,6 @@ class Compress::LZ4::Writer < ::IO
   getter uncompressed_bytes = 0u64
   @context : LibLZ4::Cctx
   @pref : LibLZ4::PreferencesT
-  @opts = LibLZ4::CompressOptionsT.new(stable_src: 0)
   @header_written = false
   MaxSrcSize = 64 * 1024
 
@@ -85,10 +84,11 @@ class Compress::LZ4::Writer < ::IO
     check_open
     write_header
     @uncompressed_bytes &+= slice.size
+    opts = LibLZ4::CompressOptionsT.new(stable_src: 1)
     until slice.empty?
       read_size = Math.min(slice.size, MaxSrcSize)
-      @opts.stable_src = slice.size > MaxSrcSize ? 1 : 0
-      ret = LibLZ4.compress_update(@context, @buffer, @buffer.size, slice, read_size, pointerof(@opts))
+      opts.stable_src = slice.size > MaxSrcSize ? 1 : 0
+      ret = LibLZ4.compress_update(@context, @buffer, @buffer.size, slice, read_size, pointerof(opts))
       raise_if_error(ret, "Failed to compress")
       @compressed_bytes &+= ret
       @output.write(@buffer[0, ret])
@@ -99,7 +99,7 @@ class Compress::LZ4::Writer < ::IO
   # Flush LZ4 lib buffers even if a block isn't full
   def flush : Nil
     check_open
-    ret = LibLZ4.flush(@context, @buffer, @buffer.size, pointerof(@opts))
+    ret = LibLZ4.flush(@context, @buffer, @buffer.size, nil)
     raise_if_error(ret, "Failed to flush")
     @compressed_bytes &+= ret
     @output.write(@buffer[0, ret])
@@ -109,7 +109,7 @@ class Compress::LZ4::Writer < ::IO
   # Ends the current LZ4 frame, the stream can still be written to, unless @sync_close
   def close
     check_open
-    ret = LibLZ4.compress_end(@context, @buffer, @buffer.size, pointerof(@opts))
+    ret = LibLZ4.compress_end(@context, @buffer, @buffer.size, nil)
     raise_if_error(ret, "Failed to end frame")
     @compressed_bytes &+= ret
     @output.write(@buffer[0, ret])


### PR DESCRIPTION
### WHY are these changes introduced?

Optimization and clarity

### WHAT is this pull request doing?

Instead of having an instance variable for CompressOptions it's now put on the stack. The struct is as of current version only used to indicate if the buffer passed to compress_update is stable (is there for the next call to compress_update, or not). flush and compress_end does not use the struct as of today, so nil can be passed instead.

### HOW can this pull request be tested?

specs